### PR TITLE
add corner case for A_JP + A_BP situation

### DIFF
--- a/src/RcsCore/ControllerBase.cpp
+++ b/src/RcsCore/ControllerBase.cpp
@@ -225,6 +225,21 @@ Rcs::ControllerBase::ControllerBase(RcsGraph* graph):
 }
 
 /*******************************************************************************
+ * Constructor based on a graph object. Takes ownership of the graph.
+ ******************************************************************************/
+Rcs::ControllerBase::ControllerBase(RcsGraph* graph, RcsCollisionMdl* cMdl):
+      graph(graph),
+      ownsGraph(false),
+      xmlRootNode(NULL),
+      xmlDoc(NULL),
+      cMdl(cMdl),
+      name("Unknown controller"),
+      xmlFile("no-xml-file-available")
+{
+    // nothing more to do in here.
+}
+
+/*******************************************************************************
  * Copy constructor doing deep copying.
  * The xml data is not copied, since this is not present after the
  * construction of the copied constructor.

--- a/src/RcsCore/ControllerBase.h
+++ b/src/RcsCore/ControllerBase.h
@@ -87,6 +87,12 @@ public:
    */
   ControllerBase(RcsGraph* graph);
 
+  /*! \brief Constructor based on a graph and its collision model. The new class
+   *         takes ownership of the given graph. Use this if you only want to add
+   *         tasks manually using addTask.
+   */
+  ControllerBase(RcsGraph* graph, RcsCollisionMdl* cMdl);
+
   /*! \brief Copy constructor doing deep copying. The new class owns a deep
    *         copy of the graph and the collision model (if any).
    */

--- a/src/RcsCore/Rcs_URDFParser.c
+++ b/src/RcsCore/Rcs_URDFParser.c
@@ -133,7 +133,13 @@ static RcsShape* parseShapeURDF(xmlNode* node, RcsBody* body)
 
             pathIdx++;
         }
-    } else {
+    }
+    else if (STRNEQ(meshFile, "file://", 7))  // for absolute path.
+    {
+        Rcs_getAbsoluteFileName(&meshFile[7], meshFileFull);
+    }
+    else
+    {
         Rcs_getAbsoluteFileName(meshFile, meshFileFull);
     }
 

--- a/src/RcsCore/Rcs_colladaParser.c
+++ b/src/RcsCore/Rcs_colladaParser.c
@@ -380,7 +380,7 @@ bool Rcs_parseTechniqueCommonNode(xmlNodePtr techiniqueCommonNode, ColladaTechni
 {
     if (!techiniqueCommonNode)
     {
-        RLOG(0, "technique_common node ptr invalid.");
+        RLOG(5, "technique_common node ptr invalid.");
         return false;
     }
 
@@ -388,7 +388,7 @@ bool Rcs_parseTechniqueCommonNode(xmlNodePtr techiniqueCommonNode, ColladaTechni
     xmlNodePtr accessorNode = getXMLChildByName(techiniqueCommonNode, "accessor");
     if (!accessorNode)
     {
-        RLOG(0, "can not parse accessor");
+        RLOG(5, "can not parse accessor");
         return false;
     }
     result &= (getXMLNodePropertyStringN(accessorNode, "source", techniqueCommon->accessorSource, 128) > 0);
@@ -396,14 +396,14 @@ bool Rcs_parseTechniqueCommonNode(xmlNodePtr techiniqueCommonNode, ColladaTechni
     result &= getXMLNodePropertyInt(accessorNode, "stride", &techniqueCommon->stride);
     if (!result)
     {
-        RLOG(0, "parse accessor node faile");
+        RLOG(5, "parse accessor node faile");
         return false;
     }
 
     xmlNodePtr parameterNode = accessorNode->children;
     if (!parameterNode)
     {
-        RLOG(0, "no parameter node");
+        RLOG(5, "no parameter node");
         return result;
     }
 
@@ -424,7 +424,7 @@ bool Rcs_parseTechniqueCommonNode(xmlNodePtr techiniqueCommonNode, ColladaTechni
 
     if ((i != parameterLen) || !result)
     {
-        RLOG(0, "parse param node error.");
+        RLOG(5, "parse param node error.");
         return false;
     }
 
@@ -443,7 +443,7 @@ bool Rcs_parseXMLNodeContentToDoubleArray(xmlNodePtr node, double* array, int ar
     xmlFree(pNodeArrayStr);
     if (!tmpRes)
     {
-        RLOG(0, "convert int array failed.");
+        RLOG(5, "convert int array failed.");
         return false;
     }
 
@@ -462,7 +462,7 @@ bool Rcs_parseXMLNodeContentToIntArray(xmlNodePtr node, int* array, int arrLen)
     xmlFree(pNodeArrayStr);
     if (!tmpRes)
     {
-        RLOG(0, "convert int array failed.");
+        RLOG(5, "convert int array failed.");
         return false;
     }
 
@@ -475,7 +475,7 @@ bool Rcs_parseSourceNode(xmlNodePtr sourceNode, ColladaSource* source)
     result &= (getXMLNodePropertyStringN(sourceNode, "id", source->id, 128) > 0);
     if (!result)
     {
-        RLOG(0, "parse source node id error.");
+        RLOG(5, "parse source node id error.");
         return false;
     }
     xmlNodePtr techiniqueCommonNode = getXMLChildByName(sourceNode, "technique_common");
@@ -484,14 +484,14 @@ bool Rcs_parseSourceNode(xmlNodePtr sourceNode, ColladaSource* source)
     source->techniqueCommon = RNALLOC(1, ColladaTechniqueCommon);
     if (!source->techniqueCommon)
     {
-        RLOG(0, "allocate memory for technique_common failed.");
+        RLOG(5, "allocate memory for technique_common failed.");
         return false;
     }
 
     result &= Rcs_parseTechniqueCommonNode(techiniqueCommonNode, source->techniqueCommon);
     if (!result)
     {
-        RLOG(0, "parse techinique common node error.");
+        RLOG(5, "parse techinique common node error.");
         return result;
     }
 
@@ -499,7 +499,7 @@ bool Rcs_parseSourceNode(xmlNodePtr sourceNode, ColladaSource* source)
     floatArrNode = getXMLChildByName(sourceNode, "float_array");
     if (!floatArrNode)
     {
-        RLOG(0, "source node has no float array node.");
+        RLOG(5, "source node has no float array node.");
         return false;
     }
 
@@ -509,14 +509,14 @@ bool Rcs_parseSourceNode(xmlNodePtr sourceNode, ColladaSource* source)
     source->array = RNALLOC(source->arrLen, double);
     if (!source->array)
     {
-        RLOG(0, "allocate memory for source array failed.");
+        RLOG(5, "allocate memory for source array failed.");
         return false;
     }
 
     result &= Rcs_parseXMLNodeContentToDoubleArray(floatArrNode, source->array, source->arrLen);
     if (!result)
     {
-        RLOG(0, "parse source node float array error");
+        RLOG(5, "parse source node float array error");
         return result;
     }
 
@@ -531,7 +531,7 @@ bool Rcs_parseInputNode(xmlNodePtr inputNode, ColladaInput* input, ColladaSource
     result &= (getXMLNodePropertyStringN(inputNode, "semantic", input->semantic, 16) > 0);
     if (!result)
     {
-        RLOG(0, "parse input node error");
+        RLOG(5, "parse input node error");
         return result;
     }
 
@@ -561,7 +561,7 @@ bool Rcs_parseVerticesNode(xmlNodePtr verticesNode, ColladaVertices* vertices, C
     result &= (getXMLNodePropertyStringN(verticesNode, "id", vertices->id, 128) > 0);
     if (!result)
     {
-        RLOG(0, "vertices node has no id");
+        RLOG(5, "vertices node has no id");
         return result;
     }
 
@@ -569,7 +569,7 @@ bool Rcs_parseVerticesNode(xmlNodePtr verticesNode, ColladaVertices* vertices, C
     inputNode = getXMLChildByName(verticesNode, "input");
     if (!inputNode)
     {
-        RLOG(0, "vertices node has no input");
+        RLOG(5, "vertices node has no input");
         return false;
     }
 
@@ -577,14 +577,14 @@ bool Rcs_parseVerticesNode(xmlNodePtr verticesNode, ColladaVertices* vertices, C
     vertices->input = RNALLOC(1, ColladaInput);
     if (!vertices->input)
     {
-        RLOG(0, "allocate memory for vertices input failed.");
+        RLOG(5, "allocate memory for vertices input failed.");
         return false;
     }
 
     result &= Rcs_parseInputNode(inputNode, vertices->input, sources, sourcesLen);
     if (!result)
     {
-        RLOG(0, "parse vertices node error, input node parsing error");
+        RLOG(5, "parse vertices node error, input node parsing error");
         return result;
     }
 
@@ -598,7 +598,7 @@ bool Rcs_parseTrianglesNode(xmlNodePtr trianglesNode, ColladaTriangles* triangle
     result &= getXMLNodePropertyInt(trianglesNode, "count", &triangles->trianglesNum);
     if (!result)
     {
-        RLOG(0, "parse triangles node property failed.");
+        RLOG(5, "parse triangles node property failed.");
         return result;
     }
 
@@ -622,7 +622,7 @@ bool Rcs_parseTrianglesNode(xmlNodePtr trianglesNode, ColladaTriangles* triangle
                     }
                     else
                     {
-                        RLOG(0, "vertices input has no array");
+                        RLOG(5, "vertices input has no array");
                     }
 
                 }
@@ -634,7 +634,7 @@ bool Rcs_parseTrianglesNode(xmlNodePtr trianglesNode, ColladaTriangles* triangle
 
     if (!result)
     {
-        RLOG(0, "parse inputs error, in triangles node");
+        RLOG(5, "parse inputs error, in triangles node");
         RFREE(triangles->inputs);  // input does not hold the data, can directly be freed.
         triangles->inputs = NULL;
         return result;
@@ -647,7 +647,7 @@ bool Rcs_parseTrianglesNode(xmlNodePtr trianglesNode, ColladaTriangles* triangle
     triangles->indexArray = RNALLOC(triangles->indexArrLen, int);
     if (!triangles->indexArray)
     {
-        RLOG(0, "can not allocate memory for index array, length=%d", triangles->indexArrLen);
+        RLOG(5, "can not allocate memory for index array, length=%d", triangles->indexArrLen);
         return false;
     }
 
@@ -656,7 +656,7 @@ bool Rcs_parseTrianglesNode(xmlNodePtr trianglesNode, ColladaTriangles* triangle
     result &= Rcs_parseXMLNodeContentToIntArray(pNode, triangles->indexArray, triangles->indexArrLen);
     if (!result)
     {
-        RLOG(0, "can not read p node content");
+        RLOG(5, "can not read p node content");
         return result;
     }
 
@@ -672,7 +672,7 @@ bool Rcs_parseMeshNode(xmlNodePtr meshNode, ColladaMesh* mesh)
     mesh->sources = RNALLOC(mesh->sourcesLen, ColladaSource);
     if (!mesh->sources)
     {
-        RLOG(0, "can not allocate memory for Source");
+        RLOG(5, "can not allocate memory for Source");
         return false;
     }
 
@@ -690,7 +690,7 @@ bool Rcs_parseMeshNode(xmlNodePtr meshNode, ColladaMesh* mesh)
     }
     if (!result)
     {
-        RLOG(0, "parse souces failed.");
+        RLOG(5, "parse souces failed.");
         return result;
     }
 
@@ -700,13 +700,13 @@ bool Rcs_parseMeshNode(xmlNodePtr meshNode, ColladaMesh* mesh)
     mesh->vertices = RNALLOC(1, ColladaVertices);
     if (!mesh->vertices)
     {
-        RLOG(0, "can not allocate memory for Vertices.");
+        RLOG(5, "can not allocate memory for Vertices.");
         return false;
     }
     result &= Rcs_parseVerticesNode(verticesNode, mesh->vertices, mesh->sources, mesh->sourcesLen);
     if (!result)
     {
-        RLOG(0, "parse vertices node failed.");
+        RLOG(5, "parse vertices node failed.");
         return result;
     }
 
@@ -716,14 +716,14 @@ bool Rcs_parseMeshNode(xmlNodePtr meshNode, ColladaMesh* mesh)
     mesh->triangles = RNALLOC(1, ColladaTriangles);
     if (!mesh->triangles)
     {
-        RLOG(0, "can not allocate memory for Triangles.");
+        RLOG(5, "can not allocate memory for Triangles.");
         return false;
     }
 
     result &= Rcs_parseTrianglesNode(trianglesNode, mesh->triangles, mesh->sources, mesh->sourcesLen, mesh->vertices);
     if (!result)
     {
-        RLOG(0, "parse triangles node failed.");
+        RLOG(5, "parse triangles node failed.");
         return result;
     }
 
@@ -738,7 +738,7 @@ bool Rcs_parseGeometryNode(xmlNodePtr geometryNode, ColladaGeometry* geometry)
     result &= (getXMLNodePropertyStringN(geometryNode, "name", geometry->name, 128) > 0);
     if (!result)
     {
-        RLOG(0, "can not parse geometry node property.");
+        RLOG(5, "can not parse geometry node property.");
         return result;
     }
 
@@ -747,13 +747,13 @@ bool Rcs_parseGeometryNode(xmlNodePtr geometryNode, ColladaGeometry* geometry)
     geometry->mesh = RNALLOC(1, ColladaMesh);
     if (!geometry->mesh)
     {
-        RLOG(0, "can not allocate memory for Mesh.");
+        RLOG(5, "can not allocate memory for Mesh.");
         return false;
     }
     result &= Rcs_parseMeshNode(meshNode, geometry->mesh);
     if (!result)
     {
-        RLOG(0, "parse mesh node failed.");
+        RLOG(5, "parse mesh node failed.");
         return result;
     }
 
@@ -769,7 +769,7 @@ bool Rcs_parseLibraryGeometriesNode(xmlNodePtr libraryGeometriesNode, ColladaLib
     libraryGeometries->geometries = RNALLOC(libraryGeometries->geometriesLen, ColladaGeometry);
     if (!libraryGeometries->geometries)
     {
-        RLOG(0, "can not allocate memory for Geometry");
+        RLOG(5, "can not allocate memory for Geometry");
         return false;
     }
 
@@ -787,7 +787,7 @@ bool Rcs_parseLibraryGeometriesNode(xmlNodePtr libraryGeometriesNode, ColladaLib
 
     if (!result)
     {
-        RLOG(0, "parse geometry node failed.");
+        RLOG(5, "parse geometry node failed.");
         return result;
     }
 
@@ -801,7 +801,7 @@ bool Rcs_parseMatrixNode(xmlNodePtr matrixNode, ColladaMatrix* matrix)
     result &= (getXMLNodePropertyStringN(matrixNode, "sid", matrix->sid, 16) > 0);
     if (!result)
     {
-        RLOG(0, "can not parse matrix node property.");
+        RLOG(5, "can not parse matrix node property.");
         return result;
     }
 
@@ -809,14 +809,14 @@ bool Rcs_parseMatrixNode(xmlNodePtr matrixNode, ColladaMatrix* matrix)
     double* array = RNALLOC(arrLen, double);
     if (!array)
     {
-        RLOG(0, "allocate memory for matrix array failed.");
+        RLOG(5, "allocate memory for matrix array failed.");
         return false;
     }
 
     result &= Rcs_parseXMLNodeContentToDoubleArray(matrixNode, array, arrLen);
     if (!result)
     {
-        RLOG(0, "parse source node float array error");
+        RLOG(5, "parse source node float array error");
         RFREE(array);
         return result;
     }
@@ -862,7 +862,7 @@ bool Rcs_parseVisualNode(xmlNodePtr node, ColladaVisualNode* visualNode)
     result &= (getXMLNodePropertyStringN(node, "type", visualNode->type, 16) > 0);
     if (!result)
     {
-        RLOG(0, "can not parse visual node property.");
+        RLOG(5, "can not parse visual node property.");
         return result;
     }
 
@@ -871,13 +871,13 @@ bool Rcs_parseVisualNode(xmlNodePtr node, ColladaVisualNode* visualNode)
     visualNode->matrix = RNALLOC(1, ColladaMatrix);
     if (!visualNode->matrix)
     {
-        RLOG(0, "can not allocate memory for visual node matrix.");
+        RLOG(5, "can not allocate memory for visual node matrix.");
         return false;
     }
     result &= Rcs_parseMatrixNode(matrixNode, visualNode->matrix);
     if (!result)
     {
-        RLOG(0, "parse matrix node failed.");
+        RLOG(5, "parse matrix node failed.");
         return result;
     }
 
@@ -886,13 +886,13 @@ bool Rcs_parseVisualNode(xmlNodePtr node, ColladaVisualNode* visualNode)
     visualNode->instanceGeometry = RNALLOC(1, ColladaInstanceGeometry);
     if (!visualNode->instanceGeometry)
     {
-        RLOG(0, "can not allocate memory for instance geometry.");
+        RLOG(5, "can not allocate memory for instance geometry.");
         return false;
     }
     result &= Rcs_parseInstanceGeometryNode(instanceGeometryNode, visualNode->instanceGeometry);
     if (!result)
     {
-        RLOG(0, "parse instance geometry node failed.");
+        RLOG(5, "parse instance geometry node failed.");
         return result;
     }
 
@@ -906,7 +906,7 @@ bool Rcs_parseVisualSceneNode(xmlNodePtr visualSceneNode, ColladaVisualScene* vi
     result &= (getXMLNodePropertyStringN(visualSceneNode, "name", visualScene->name, 16) > 0);
     if (!result)
     {
-        RLOG(0, "can not parse visual scene node property.");
+        RLOG(5, "can not parse visual scene node property.");
         return result;
     }
 
@@ -914,7 +914,7 @@ bool Rcs_parseVisualSceneNode(xmlNodePtr visualSceneNode, ColladaVisualScene* vi
     visualScene->nodes = RNALLOC(visualScene->nodesLen, ColladaVisualNode);
     if (!visualScene->nodes)
     {
-        RLOG(0, "can not allocate memory for visual node");
+        RLOG(5, "can not allocate memory for visual node");
         return false;
     }
 
@@ -932,7 +932,7 @@ bool Rcs_parseVisualSceneNode(xmlNodePtr visualSceneNode, ColladaVisualScene* vi
 
     if (!result)
     {
-        RLOG(0, "parse geometry node failed.");
+        RLOG(5, "parse geometry node failed.");
         return result;
     }
 
@@ -948,7 +948,7 @@ bool Rcs_parseLibraryVisualScenesNode(xmlNodePtr libraryVisualScenesNode, Collad
     libraryVisualScenes->visualScenes = RNALLOC(libraryVisualScenes->visualScenesLen, ColladaVisualScene);
     if (!libraryVisualScenes->visualScenes)
     {
-        RLOG(0, "can not allocate memory for Visual Scenes");
+        RLOG(5, "can not allocate memory for Visual Scenes");
         return false;
     }
 
@@ -966,7 +966,7 @@ bool Rcs_parseLibraryVisualScenesNode(xmlNodePtr libraryVisualScenesNode, Collad
 
     if (!result)
     {
-        RLOG(0, "parse geometry node failed.");
+        RLOG(5, "parse geometry node failed.");
         return result;
     }
 
@@ -1024,7 +1024,7 @@ bool Rcs_applyColladaInternalTransformation(Collada* collada)
     }
     else
     {
-        RLOG(0, "failed to apply transformation");
+        RLOG(5, "failed to apply transformation");
         return false;
     }
 
@@ -1039,13 +1039,13 @@ bool Rcs_parseColladaNode(xmlNodePtr colladaNode, Collada* collada)
     collada->libraryGeometries = RNALLOC(1, ColladaLibraryGeometries);
     if (!collada->libraryGeometries)
     {
-        RLOG(0, "can not allocate memory for LibraryGeometries");
+        RLOG(5, "can not allocate memory for LibraryGeometries");
         return false;
     }
     result &= Rcs_parseLibraryGeometriesNode(libraryGeometriesNode, collada->libraryGeometries);
     if (!result)
     {
-        RLOG(0, "parse collada node failed.");
+        RLOG(5, "parse collada node failed.");
         return false;
     }
 
@@ -1054,20 +1054,20 @@ bool Rcs_parseColladaNode(xmlNodePtr colladaNode, Collada* collada)
     collada->libraryVisualScenes = RNALLOC(1, ColladaLibraryVisualScenes);
     if (!collada->libraryVisualScenes)
     {
-        RLOG(0, "can not allocate memory for LibraryVisualScenes");
+        RLOG(5, "can not allocate memory for LibraryVisualScenes");
         return false;
     }
     result &= Rcs_parseLibraryVisualScenesNode(libraryVisualScenesNode, collada->libraryVisualScenes);
     if (!result)
     {
-        RLOG(0, "parse collada node failed.");
+        RLOG(5, "parse collada node failed.");
         return false;
     }
 
     result &= Rcs_applyColladaInternalTransformation(collada);
     if (!result)
     {
-        RLOG(0, "can not applay collada internal transformation.");
+        RLOG(5, "can not applay collada internal transformation.");
         return false;
     }
 
@@ -1083,14 +1083,14 @@ bool Rcs_parseDAEFile(const char* filename, Collada** collada)
     colladaNode = parseXMLFile(filename, "COLLADA", &doc);
     if (!colladaNode)
     {
-        RLOG(0, "can not parse the collada file:%s", filename);
+        RLOG(5, "can not parse the collada file:%s", filename);
         return false;
     }
 
     *collada = RNALLOC(1, Collada);
     if (!(*collada))
     {
-        RLOG(0, "can not allocate memory for Collada object");
+        RLOG(5, "can not allocate memory for Collada object");
         xmlFreeDoc(doc);
         return false;
     }
@@ -1098,7 +1098,7 @@ bool Rcs_parseDAEFile(const char* filename, Collada** collada)
     result &= Rcs_parseColladaNode(colladaNode, *collada);
     if (!result)
     {
-        RLOG(0, "parse collada node error.");
+        RLOG(5, "parse collada node error.");
         Rcs_freeCollada(*collada);
         RFREE(*collada);
         *collada = NULL;
@@ -1165,11 +1165,11 @@ bool Rcs_parseMeshDataFromCollada(RcsMeshData* meshData, Collada* collada)
     meshData->vertices = RNALLOC(meshData->nVertices * 3, double);
     meshData->faces = RNALLOC(meshData->nFaces * 3, unsigned int);
 
-    RLOG(0, "vertices=%u, totalTriangles=%u", meshData->nVertices, meshData->nFaces);
+    RLOG(5, "vertices=%u, totalTriangles=%u", meshData->nVertices, meshData->nFaces);
 
     if (!meshData->vertices || !meshData->faces)
     {
-        RLOG(0, "can not allocate memory for RcsMeshData");
+        RLOG(5, "can not allocate memory for RcsMeshData");
         RFREE(meshData->vertices);
         RFREE(meshData->faces);
         meshData->vertices = NULL;
@@ -1206,7 +1206,7 @@ bool Rcs_parseMeshDataFromCollada(RcsMeshData* meshData, Collada* collada)
 
     if (count != meshData->nVertices * 3)
     {
-        RLOG(0, "copy vertices error");
+        RLOG(5, "copy vertices error");
         RFREE(meshData->vertices);
         RFREE(meshData->faces);
         meshData->vertices = NULL;
@@ -1248,7 +1248,7 @@ bool Rcs_parseMeshDataFromCollada(RcsMeshData* meshData, Collada* collada)
 
     if (count != meshData->nFaces * 3)
     {
-        RLOG(0, "copy faces index error");
+        RLOG(5, "copy faces index error");
         RFREE(meshData->vertices);
         RFREE(meshData->faces);
         meshData->vertices = NULL;

--- a/src/RcsCore/Rcs_graph.h
+++ b/src/RcsCore/Rcs_graph.h
@@ -683,6 +683,13 @@ void RcsGraph_copyResizeableShapes(RcsGraph* dst, const RcsGraph* src,
  */
 RcsGraph* RcsGraph_cloneSubGraph(const RcsGraph* src, RcsBody* target);
 
+/*! \ingroup RcsGraphFunctions
+ *  \brief add suffix to the name of all bodies and all joints of the graph.
+ *
+ *  \param[in] src      Valid pointer to graph.
+ *  \param[in] suffix   the suffix to be added to every component of the graph.
+ */
+void RcsGraph_addNameSuffix(RcsGraph* src, const char* suffix);
 
 /**
  * @name Joints

--- a/src/RcsUtils/URDFGenerator/URDFGenerator.cpp
+++ b/src/RcsUtils/URDFGenerator/URDFGenerator.cpp
@@ -114,7 +114,8 @@ void URDFGenerator::addLinkAccordingToBody(URDFElement* robot, RcsBody* body)
 
     link->addAttribute("name", body->name);
 
-    RLOG(0, "handling Rcs body, current body=%s, parent=%s", body->name, body->parent ? body->parent->name : "NULL");
+    auto num = RcsBody_numJoints(body);
+    RLOG(0, "handling Rcs body, current body=%s, parent=%s, jointNumber=%d", body->name, body->parent ? body->parent->name : "NULL", num);
 
     // intertial
     handlingInertial(body, link.get());
@@ -129,7 +130,7 @@ void URDFGenerator::addLinkAccordingToBody(URDFElement* robot, RcsBody* body)
 
     // if exist multiple joints, add dummy links.
     // if body->rigid_body_joints, it should be a floating joint after urdf.
-    if (body->jnt && body->jnt->next) {
+    if (num > 1) {
         int dummyNum = 0;
         RCSBODY_TRAVERSE_JOINTS(body) {
             if (dummyNum != 0) {
@@ -140,6 +141,16 @@ void URDFGenerator::addLinkAccordingToBody(URDFElement* robot, RcsBody* body)
             }
             ++dummyNum;
         }
+    }
+
+    if (body->jnt && body->A_BP && !HTr_isIdentity(body->A_BP))  // -->A_JP-->A_BP. In this situation, we need an additional dummy link for relative transformation A_BP
+    {
+        RLOG(0, "add additional dummy link because of A_BP.");
+
+        auto dummyLink = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("link"));
+        std::string jointName = body->jnt->name;
+        dummyLink->addAttribute("name", jointName + "_to_A_BP_dummy");
+        robot->addSubElement(std::move(dummyLink));
     }
 }
 
@@ -160,36 +171,23 @@ void URDFGenerator::addJointAccordingToLink(URDFElement* robot, RcsBody* body)
     }
 
     unsigned int jointNumber = RcsBody_numJoints(body);
-    RLOG(0, "handling joint for body=%s, numJoints=%u", body->name, jointNumber);
+    RLOG(0, "handling joint for body=%s, numJoints=%u, A_BP=%s", body->name, jointNumber, body->A_BP ? (HTr_isIdentity(body->A_BP) ? "Identity" : "Not Identity") : "NULL");
 
-    if (jointNumber <= 1) {  // if the joint is the unique joint connects two body, then it is easy.
+    if (jointNumber == 0)  // for fixed joint.
+    {
         auto uniqueJoint = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("joint"));
 
         // parent link
         auto parent = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("parent"));
         if (body->parent) {
-            if (body->jnt) {
-                // joint name, type attribute and axis element
-                setJointAttribute(body->jnt, uniqueJoint.get());
-            }
-            else
-            {
-                uniqueJoint->addAttribute("name", std::string(body->name) + "_to_" + body->parent->name + "_dummy_joint");
-                uniqueJoint->addAttribute("type","fixed");
-            }
+            uniqueJoint->addAttribute("name", std::string(body->name) + "_to_" + body->parent->name +  "_dummy_joint");
+            uniqueJoint->addAttribute("type","fixed");
             parent->addAttribute("link", body->parent->name);
         }
         else
         {
-            if (body->jnt) {
-                // joint name, type attribute and axis element
-                setJointAttribute(body->jnt, uniqueJoint.get());
-            }
-            else
-            {
-                uniqueJoint->addAttribute("name", std::string(body->name) + "_to_dummy_base_dummy_joint");
-                uniqueJoint->addAttribute("type","fixed");
-            }
+            uniqueJoint->addAttribute("name", std::string(body->name) + "_to_dummy_base_dummy_joint");
+            uniqueJoint->addAttribute("type","fixed");
             parent->addAttribute("link", "dummy_base");
         }
         uniqueJoint->addSubElement(std::move(parent));
@@ -200,23 +198,7 @@ void URDFGenerator::addJointAccordingToLink(URDFElement* robot, RcsBody* body)
         uniqueJoint->addSubElement(std::move(child));
 
         // origin
-        if (body->jnt && body->jnt->A_JP) {
-            auto origin = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("origin"));
-
-            std::stringstream translation;
-            std::stringstream rotation;
-            translation <<  body->jnt->A_JP->org[0] << " " <<  body->jnt->A_JP->org[1] << " " << body->jnt->A_JP->org[2];
-
-            double rpy[3];
-            computeEulerAngles(rpy, body->jnt->A_JP->rot, EulOrdXYZs);
-            rotation << rpy[0] << " " << rpy[1] << " " << rpy[2];
-
-            origin->addAttribute("xyz", translation.str());
-            origin->addAttribute("rpy", rotation.str());
-            uniqueJoint->addSubElement(std::move(origin));
-        }
-        else if (!body->jnt && body->A_BP)  // for fixed dummy joint
-        {
+        if (body->A_BP) {
             auto origin = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("origin"));
 
             std::stringstream translation;
@@ -232,15 +214,66 @@ void URDFGenerator::addJointAccordingToLink(URDFElement* robot, RcsBody* body)
             uniqueJoint->addSubElement(std::move(origin));
         }
 
-        // limit
-        if (body->jnt) {
-            auto limit = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("limit"));
-            limit->addAttribute("effort", std::to_string(body->jnt->maxTorque > 1000 ? 1000 : body->jnt->maxTorque));
-            limit->addAttribute("velocity", std::to_string(body->jnt->speedLimit > 1000 ? 1000 : body->jnt->speedLimit));
-            limit->addAttribute("lower", std::to_string(body->jnt->q_min));
-            limit->addAttribute("upper", std::to_string(body->jnt->q_max));
-            uniqueJoint->addSubElement(std::move(limit));
+        robot->addSubElement(std::move(uniqueJoint));
+    }
+    else if (jointNumber == 1)  // corner case for -->A_JP-->A_BP situation. create an additional dummy joint
+    {
+        auto uniqueJoint = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("joint"));
+        const std::string dummyLinkName = std::string(body->jnt->name) + "_to_A_BP_dummy";
+
+        // joint name, type attribute and axis element
+        setJointAttribute(body->jnt, uniqueJoint.get());
+
+        // parent link
+        auto parent = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("parent"));
+        if (body->parent)
+        {
+            parent->addAttribute("link", body->parent->name);
         }
+        else
+        {
+            parent->addAttribute("link", "dummy_base");
+        }
+        uniqueJoint->addSubElement(std::move(parent));
+
+        // child link
+        if (body->A_BP && !HTr_isIdentity(body->A_BP))
+        {
+            auto child = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("child"));
+            child->addAttribute("link",  dummyLinkName);  // the child body is the dummy link for the A_BP.
+            uniqueJoint->addSubElement(std::move(child));
+        }
+        else
+        {
+            auto child = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("child"));
+            child->addAttribute("link",  body->name);
+            uniqueJoint->addSubElement(std::move(child));
+        }
+
+        // origin
+        if (body->jnt->A_JP) {
+            auto origin = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("origin"));
+
+            std::stringstream translation;
+            std::stringstream rotation;
+            translation <<  body->jnt->A_JP->org[0] << " " <<  body->jnt->A_JP->org[1] << " " << body->jnt->A_JP->org[2];
+
+            double rpy[3];
+            computeEulerAngles(rpy, body->jnt->A_JP->rot, EulOrdXYZs);
+            rotation << rpy[0] << " " << rpy[1] << " " << rpy[2];
+
+            origin->addAttribute("xyz", translation.str());
+            origin->addAttribute("rpy", rotation.str());
+            uniqueJoint->addSubElement(std::move(origin));
+        }
+
+        // limit
+        auto limit = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("limit"));
+        limit->addAttribute("effort", std::to_string(body->jnt->maxTorque > 1000 ? 1000 : body->jnt->maxTorque));
+        limit->addAttribute("velocity", std::to_string(body->jnt->speedLimit > 1000 ? 1000 : body->jnt->speedLimit));
+        limit->addAttribute("lower", std::to_string(body->jnt->q_min));
+        limit->addAttribute("upper", std::to_string(body->jnt->q_max));
+        uniqueJoint->addSubElement(std::move(limit));
 
         // mimic
         if (body->jnt->coupledJointName)
@@ -260,11 +293,50 @@ void URDFGenerator::addJointAccordingToLink(URDFElement* robot, RcsBody* body)
         }
 
         robot->addSubElement(std::move(uniqueJoint));
+
+        // handling A_BP dummy joint
+        if (body->A_BP && !HTr_isIdentity(body->A_BP))
+        {
+            auto dummyJoint = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("joint"));
+            dummyJoint->addAttribute("name", std::string("A_BP_to_") + body->name + "_dummy_joint");
+            dummyJoint->addAttribute("type","fixed");
+            auto dummyParent = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("parent"));
+            dummyParent->addAttribute("link", dummyLinkName);
+            dummyJoint->addSubElement(std::move(dummyParent));
+            auto dummyChild = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("child"));
+            dummyChild->addAttribute("link",  body->name);
+            dummyJoint->addSubElement(std::move(dummyChild));
+
+            if (body->A_BP)
+            {
+                RMSG(0, "condition fufilled");
+                auto dummyOrigin = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("origin"));
+
+                std::stringstream translation;
+                std::stringstream rotation;
+                translation <<  body->A_BP->org[0] << " " <<  body->A_BP->org[1] << " " << body->A_BP->org[2];
+
+                double rpy[3];
+                computeEulerAngles(rpy, body->A_BP->rot, EulOrdXYZs);
+                rotation << rpy[0] << " " << rpy[1] << " " << rpy[2];
+
+                dummyOrigin->addAttribute("xyz", translation.str());
+                dummyOrigin->addAttribute("rpy", rotation.str());
+                dummyJoint->addSubElement(std::move(dummyOrigin));
+            }
+            robot->addSubElement(std::move(dummyJoint));
+        }
     }
-    else  // multiple joints
-    {  // otherweise, we must add dummy subjoints.
-        int num = 0;
+    else if (jointNumber > 1)  // create dummy joint after last joint.
+    {
+        std::string dummyLinkName;
+        unsigned int num = 0;
         RCSBODY_TRAVERSE_JOINTS(body) {
+            if (num == jointNumber - 1)
+            {
+                dummyLinkName = std::string(body->jnt->name) + "_to_A_BP_dummy";
+            }
+
             auto subJoint = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("joint"));
 
             // joint name, type attribute and axis element
@@ -285,7 +357,13 @@ void URDFGenerator::addJointAccordingToLink(URDFElement* robot, RcsBody* body)
             auto child = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("child"));
             if (JNT->next) {
                 child->addAttribute("link", std::string(JNT->name) + "_to_" + JNT->next->name + "_dummy");
-            } else {
+            }
+            else if (!JNT->next && body->A_BP && !HTr_isIdentity(body->A_BP))
+            {
+                child->addAttribute("link",  dummyLinkName);
+            }
+            else
+            {
                 child->addAttribute("link",  body->name);
             }
             subJoint->addSubElement(std::move(child));
@@ -339,6 +417,38 @@ void URDFGenerator::addJointAccordingToLink(URDFElement* robot, RcsBody* body)
 
             robot->addSubElement(std::move(subJoint));
             ++num;
+        }
+
+        if (body->A_BP && !HTr_isIdentity(body->A_BP))
+        {
+            auto dummyJoint = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("joint"));
+            dummyJoint->addAttribute("name", std::string("A_BP_to_") + body->name + "_dummy_joint");
+            dummyJoint->addAttribute("type","fixed");
+            auto dummyParent = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("parent"));
+            dummyParent->addAttribute("link", dummyLinkName);
+            dummyJoint->addSubElement(std::move(dummyParent));
+            auto dummyChild = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("child"));
+            dummyChild->addAttribute("link",  body->name);
+            dummyJoint->addSubElement(std::move(dummyChild));
+
+            if (body->A_BP)
+            {
+                RMSG(0, "condition fufilled");
+                auto dummyOrigin = std::unique_ptr<Rcs::URDFElement>(new (std::nothrow) Rcs::URDFElement("origin"));
+
+                std::stringstream translation;
+                std::stringstream rotation;
+                translation <<  body->A_BP->org[0] << " " <<  body->A_BP->org[1] << " " << body->A_BP->org[2];
+
+                double rpy[3];
+                computeEulerAngles(rpy, body->A_BP->rot, EulOrdXYZs);
+                rotation << rpy[0] << " " << rpy[1] << " " << rpy[2];
+
+                dummyOrigin->addAttribute("xyz", translation.str());
+                dummyOrigin->addAttribute("rpy", rotation.str());
+                dummyJoint->addSubElement(std::move(dummyOrigin));
+            }
+            robot->addSubElement(std::move(dummyJoint));
         }
     }
 }

--- a/src/RcsUtils/URDFGenerator/URDFGenerator.h
+++ b/src/RcsUtils/URDFGenerator/URDFGenerator.h
@@ -85,7 +85,7 @@ class URDFGenerator final
     RcsGraph* m_graph;
     std::unique_ptr<URDFElement> m_robot;
     bool m_withFloatingJoint;
-};
+    bool m_withDummyBase;
 }
 
 #endif // URDFGENERATOR_H


### PR DESCRIPTION
Add handling for the corner case A_JP + A_BP.
If one body has valid joints and also have an A_BP transformation. It looks like --> A_JP_1 -->A_JP_n --> A_BP. It only occurs if the joint axis in the original urdf is not aligned with the positive axis direction. So for this situation, the Rcs will firstly apply a rotation transformation, to make the rotation axis aligned with the right direction. Then it will create the A_BP. With A_BP Rcs will rotate the Body to the right direction. So if we want to export this situation, we need to add an additional dummy link and dummy joint between the A_JP_n and A_BP in order to reflect the A_BP relative transformation for the body.